### PR TITLE
Use runner.conf for run options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ Gemfile.lock
 
 # Ignore IDE files
 /.idea
+runner.conf
+

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@
 # OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 # *********************************************************************************
-
+#
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
@@ -38,6 +38,7 @@ require 'openstudio/extension/rake_task'
 require 'urbanopt/scenario'
 rake_task = OpenStudio::Extension::RakeTask.new
 rake_task.set_extension_class(URBANopt::Scenario::Extension)
+
 require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 

--- a/lib/urbanopt/scenario/default_reports/validator.rb
+++ b/lib/urbanopt/scenario/default_reports/validator.rb
@@ -28,7 +28,6 @@
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 # *********************************************************************************
 
-require 'openstudio/extension'
 require 'json'
 
 module URBANopt

--- a/lib/urbanopt/scenario/extension.rb
+++ b/lib/urbanopt/scenario/extension.rb
@@ -34,18 +34,6 @@ module URBANopt
   module Scenario
     class Extension < OpenStudio::Extension::Extension
 
-      # set NUM_PARALLEL 
-      OpenStudio::Extension::Extension::NUM_PARALLEL = 7
-
-      # set MAX_DATAPOINTS to
-      OpenStudio::Extension::Extension::MAX_DATAPOINTS = 1000
-
-      # set VERBOSE to true
-      OpenStudio::Extension::Extension::VERBOSE = true
-      
-      # set DO_SIMULATIONS to true
-      OpenStudio::Extension::Extension::DO_SIMULATIONS = true
-
       def initialize
         super
         @root_dir = File.absolute_path(File.join(File.dirname(__FILE__), '..', '..', '..'))

--- a/lib/urbanopt/scenario/scenario_runner_osw.rb
+++ b/lib/urbanopt/scenario/scenario_runner_osw.rb
@@ -83,7 +83,8 @@ module URBANopt
       # [return:] _Array_ Returns array of all SimulationFiles, even those created previously, for Scenario.
       def run(scenario, force_clear = false)
 
-        # instantiate openstudio runner
+        # instantiate openstudio runner - use the defaults for now. If need to change then create
+        # the runner.conf file (i.e. run `rake openstudio:runner:init`)
         runner = OpenStudio::Extension::Runner.new(scenario.root_dir)
 
         # create simulation files
@@ -138,13 +139,16 @@ module URBANopt
         # failures 
         failures = []
         # run building_osws
-        building_failures = runner.run_osws(building_osws, num_parallel = Extension::NUM_PARALLEL, max_to_run = Extension::MAX_DATAPOINTS)
+        # building_failures = runner.run_osws(building_osws, num_parallel = Extension::NUM_PARALLEL, max_to_run = Extension::MAX_DATAPOINTS)
+        building_failures = runner.run_osws(building_osws)
         failures << building_failures
         # run district_system_osws
-        district_system_failures = runner.run_osws(district_system_osws, num_parallel = Extension::NUM_PARALLEL, max_to_run = Extension::MAX_DATAPOINTS)
+        # district_system_failures = runner.run_osws(district_system_osws, num_parallel = Extension::NUM_PARALLEL, max_to_run = Extension::MAX_DATAPOINTS)
+        district_system_failures = runner.run_osws(district_system_osws)
         failures << district_system_failures
         # run transformer_osws
-        transformer_failures = runner.run_osws(transformer_osws, num_parallel = Extension::NUM_PARALLEL, max_to_run = Extension::MAX_DATAPOINTS)
+        # transformer_failures = runner.run_osws(transformer_osws, num_parallel = Extension::NUM_PARALLEL, max_to_run = Extension::MAX_DATAPOINTS)
+        transformer_failures = runner.run_osws(transformer_osws)
         failures << transformer_failures
 
         # puts "failures = #{failures}"

--- a/urbanopt-scenario-gem.gemspec
+++ b/urbanopt-scenario-gem.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'json_pure'
   spec.add_dependency 'openstudio-extension', '~> 0.1.0'
   spec.add_dependency 'public_suffix', '~> 3.0.3'
-  spec.add_dependency 'urbanopt-core', '~> 0.0.1'
+  spec.add_dependency 'urbanopt-core', '~> 0.1.0'
 end


### PR DESCRIPTION
This PR used the updated openstudio-extension-gem method to pass in the runner options. There are defaults and the best way to change them is to update your runner.conf file in the project root. To generate the runner.conf, simply run `rake openstudio:runner:init`. You will need to make sure that you are pulling the most recent version of extension-gem which is on a branch.

Fixes #45 