### PR TITLE
GitHub security

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,13 @@
   },
   "author": "NREL",
   "dependencies": {
+    "braces": ">=2.3.1",
     "highlight.js": "^9.15.6",
     "json-schema-ref-parser": "^6.1.0",
     "json-schema-view-js": "git+https://git@github.com/bgschiller/json-schema-view-js.git",
+    "js-yaml": ">=3.13.1",
+    "serialize-javascript": ">=2.1.1",
+    "set-value": ">=2.0.1",
     "vuepress": "^0.14.10",
     "webpack-dev-middleware": "^3.6.0"
   },

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,17 +10,17 @@
   },
   "author": "NREL",
   "dependencies": {
-    "braces": ">=2.3.1",
     "highlight.js": "^9.15.6",
     "json-schema-ref-parser": "^6.1.0",
     "json-schema-view-js": "git+https://git@github.com/bgschiller/json-schema-view-js.git",
-    "js-yaml": ">=3.13.1",
-    "serialize-javascript": ">=2.1.1",
-    "set-value": ">=2.0.1",
     "vuepress": "^0.14.10",
     "webpack-dev-middleware": "^3.6.0"
   },
   "devDependencies": {
-    "gh-pages": "^2.0.1"
+    "braces": ">=2.3.1",
+    "gh-pages": "^2.0.1",
+    "js-yaml": ">=3.13.1",
+    "serialize-javascript": ">=2.1.1",
+    "set-value": ">=2.0.1"
   }
 }


### PR DESCRIPTION
Upgrade package versions to close security holes identified by GitHub.

@kflemin, I branched off of the post-process branch, not develop. My theory is that we're all using the post-process branch so the security update should be on that. What's your opinion?
@kflemin, I updated regular dependencies, not dev dependencies. My theory is that dev dependencies are above and beyond regular dependencies, so doing it where I did covers all our bases. What's your opinion on that theory?

This addresses [docs issue # 8](https://github.com/urbanopt/urbanopt.github.io/issues/8)