### PR TITLE
make default timeseries csv for scenario; update adding feature times…

### DIFF
--- a/lib/urbanopt/scenario/default_reports/timeseries_csv.rb
+++ b/lib/urbanopt/scenario/default_reports/timeseries_csv.rb
@@ -159,7 +159,7 @@ module URBANopt
         def save_data(path)
           File.open(path, 'w') do |f|
             f.puts @column_names.join(',')
-            n = @data[@column_names[0]].size
+            n = @data[@column_names[0]].size - 1
 
             (0..n).each do |i|
               line = []

--- a/lib/urbanopt/scenario/default_reports/timeseries_csv.rb
+++ b/lib/urbanopt/scenario/default_reports/timeseries_csv.rb
@@ -188,7 +188,6 @@ module URBANopt
         # +other+ - _TimeseriesCSV_ - An object of TimeseriesCSV class.
         ##
         def add_timeseries_csv(other)
-          @path = other.path
 
           # initialize first_report_datetime with the incoming first_report_datetime if its nil.
           if @first_report_datetime.nil?
@@ -223,6 +222,9 @@ module URBANopt
             else
               @data[column_name] = new_values
             end
+          end
+          if !@data.nil?
+            save_data(@path)
           end
         end
       end

--- a/lib/urbanopt/scenario/scenario_post_processor_default.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_default.rb
@@ -46,11 +46,11 @@ module URBANopt
       # +scenario_base+ - _ScenarioBase_ - An object of ScenarioBase class.
       def initialize(scenario_base)
         super(scenario_base)
-        @scenario_result = URBANopt::Scenario::DefaultReports::ScenarioReport.new
-        @scenario_result.id = scenario_base.name
-        @scenario_result.name = scenario_base.name
-        @scenario_result.directory_name = scenario_base.run_dir
-
+        
+        initialization_hash = {:directory_name => scenario_base.run_dir, :name => scenario_base.name, :id => scenario_base.name,
+          :timeseries_csv => {:path => File.join(scenario_base.run_dir, 'scenario_timeseries.csv') }}
+        @scenario_result = URBANopt::Scenario::DefaultReports::ScenarioReport.new(initialization_hash)
+        
         @@logger ||= URBANopt::Scenario::DefaultReports.logger
       end
 


### PR DESCRIPTION
this PR makes it so that 

(a) a scenario has its own timeseries csv by default (rather than linking to the timeseries csv of the most recently added feature report)

(b) every time a feature report timeseries csv is added to a scenario report, the scenario report timeseries csv is updated and saved