### PR TITLE
Add function to save scenario-level results to sql file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # elsif allow_local
 #   gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'develop'
 # end
-#
+
 # if allow_local && File.exist?('../openstudio-common-measures-gem')
 #   gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 # elsif allow_local
@@ -40,7 +40,5 @@ end
 
 # simplecov has an unnecessary dependency on native json gem, use fork that does not require this
 gem 'simplecov', github: 'NREL/simplecov'
-# gem 'rdoc'
 
-# Fix rack version temporarily to work with Ruby 2.2.4
-gem 'rack' , '2.1.2'
+gem 'sqlite3'

--- a/lib/urbanopt/scenario/default_reports/scenario_report.rb
+++ b/lib/urbanopt/scenario/default_reports/scenario_report.rb
@@ -40,14 +40,16 @@ require 'json-schema'
 
 require 'json'
 require 'pathname'
+require 'sqlite3'
 
 module URBANopt
   module Scenario
     module DefaultReports
       ##
-      # ScenarioReport can generate two types of reports from a scenario.
+      # ScenarioReport can generate three types of reports from a scenario.
       # The first is a JSON format saved to 'default_scenario_report.json'.
       # The second is a CSV format saved to 'default_scenario_report.csv'.
+      # The third is a SQL database format saved to 'default_scenario_report.db'.
       ##
       class ScenarioReport
         attr_accessor :id, :name, :directory_name, :timesteps_per_hour, :number_of_not_started_simulations,
@@ -141,12 +143,78 @@ module URBANopt
           File.join(@directory_name, @file_name + '.csv')
         end
 
+
+        # Create database file with scenario-level results
+        #   Sum values for each timestep across all features. Save to new table in a new database
+        # 
+        # +scenario_name_with_type+ - _String_ - File name of scenario being aggregated
+        def create_scenario_db_file(scenario_name_with_type)
+            scenario_name = scenario_name_with_type.split('.')[0]  # Get rid of file extension. This way we can pass in the scenario name from CLI
+            feature_list = Pathname.new("#{@directory_name}/run/#{scenario_name}").children.select(&:directory?)  # Folders in the run/scenario directory
+            feature_1_path, feature_1_name = File.split(feature_list[0])  # This is used for time_db only
+
+            puts "MAKING SCENARIO DB"
+            db_path = File.join(@directory_name, "run", scenario_name, "default_scenario_report.db")
+            scenario_db = SQLite3::Database.open db_path
+            # scenario_db = SQLite3::Database.open "#{@directory_name}run/#{scenario_name}/default_scenario_report.db"
+            scenario_db.execute "CREATE TABLE IF NOT EXISTS ReportData(
+                TimeIndex INTEGER,
+                ReportDataDictionaryIndex INTEGER,
+                Value INTEGER
+                )"
+            time_db = SQLite3::Database.open "#{@directory_name}run/#{scenario_name}/#{feature_1_name}/eplusout.sql"  # This feels icky to open the db just to get the TimeIndexes
+            time_db.results_as_hash = true
+            time_query = time_db.query "SELECT DISTINCT TimeIndex FROM ReportData WHERE (TimeIndex % 2) != 0"
+            # Odd TimeIndexes use the specified timestep, even TimeIndexes use hourly timestep, as shown in ReportDataDictionary
+
+            time_query.each { |time_segment|  # Loop through each (odd-only) TimeIndex, to aggregate all Value's for that time_segment
+                value_hash = {:elec_val => 0, :gas_val => 0}
+                feature_list.each { |feature|  # Loop through each feature in the scenario
+                    feature_path, feature_name = File.split(feature)  # Separate the folder name from the rest of the path
+                    feature_db = SQLite3::Database.open "#{@directory_name}run/#{scenario_name}/#{feature_name}/eplusout.sql"
+                    feature_db.results_as_hash = true
+
+                    # RDDI == 11 is the timestep value for facility electricity
+                    elec_query = feature_db.query "SELECT *
+                        FROM ReportData
+                        WHERE TimeIndex=?
+                        AND ReportDataDictionaryIndex=11", time_segment['TimeIndex']
+
+                    elec_query.each { |row|  # Add up all the values for electricity usage across all Features at this timestep
+                        value_hash[:elec_val] += Float(row['Value'])
+                    }  # End elec_query
+
+                    # RDDI == 252 is the timestep value for facility gas
+                    gas_query = feature_db.query "SELECT *
+                        FROM ReportData
+                        WHERE TimeIndex=?
+                        AND ReportDataDictionaryIndex=252", time_segment['TimeIndex']
+                    
+                    gas_query.each { |row|
+                        value_hash[:gas_val] += Float(row['Value'])
+                    }  # End gas_query
+                    gas_query.close
+                    elec_query.close
+                    feature_db.close
+                }  # End feature_list loop
+
+                # Put summed Values into the database
+                scenario_db.execute("INSERT INTO ReportData (TimeIndex, ReportDataDictionaryIndex, Value) VALUES (?, ?, ?)",
+                    Integer(time_segment['TimeIndex']), 11, value_hash[:elec_val])
+                scenario_db.execute("INSERT INTO ReportData (TimeIndex, ReportDataDictionaryIndex, Value) VALUES (?, ?, ?)",
+                    Integer(time_segment['TimeIndex']), 252, value_hash[:gas_val])
+
+            }  # End time_query loop
+            puts "SCENARIO DB DONE"
+        end
+
+        
         ##
         # Saves the 'default_feature_report.json' and 'default_scenario_report.csv' files
         ##
         # [parameters]:
         # +file_name+ - _String_ - Assign a name to the saved scenario results file
-        def save(file_name = 'default_scenario_report')
+        def save(file_name = 'default_scenario_report', scenario_file_name='baseline_scenario.csv')
           # reassign the initialize local variable @file_name to the file name input.
           @file_name = file_name
 
@@ -184,6 +252,7 @@ module URBANopt
             @timeseries_csv.path = File.join(@directory_name, 'default_scenario_report.csv')
           end
           return true
+          create_scenario_db_file(scenario_file_name)
         end
 
         ##

--- a/lib/urbanopt/scenario/default_reports/scenario_report.rb
+++ b/lib/urbanopt/scenario/default_reports/scenario_report.rb
@@ -251,8 +251,8 @@ module URBANopt
           else
             @timeseries_csv.path = File.join(@directory_name, 'default_scenario_report.csv')
           end
-          return true
           create_scenario_db_file(scenario_file_name)
+          return true
         end
 
         ##


### PR DESCRIPTION
### Addresses CLI issue [#49](https://github.com/urbanopt/urbanopt-cli/issues/49)

### Pull Request Description

Add a new method to save scenario-level results in a sql database alongside the csv and json scenario-level files already created. Wired this up to the CLI so it gets called when `uo -a` is called by the user

### Checklist

- [ ] All ci tests pass (green)
- [ ] This branch is up-to-date with develop
