### PR TITLE
added timeseries outputs for heat rejection end uses

### DIFF
--- a/lib/measures/default_feature_reports/measure.rb
+++ b/lib/measures/default_feature_reports/measure.rb
@@ -643,6 +643,8 @@ class DefaultFeatureReports < OpenStudio::Measure::ReportingMeasure
       'Fans:Electricity',
       'Pumps:Electricity',
       'WaterSystems:Electricity',
+      'HeatRejection:Electricity',
+      'HeatRejection:Gas',
       'Heating:Gas',
       'WaterSystems:Gas',
       'InteriorEquipment:Gas',

--- a/lib/urbanopt/scenario/default_reports/schema/scenario_csv_columns.txt
+++ b/lib/urbanopt/scenario/default_reports/schema/scenario_csv_columns.txt
@@ -10,6 +10,8 @@ InteriorEquipment:Electricity
 Fans:Electricity
 Pumps:Electricity
 WaterSystems:Electricity
+HeatRejection:Electricity
+HeatRejection:Gas
 Heating:Gas
 WaterSystems:Gas
 InteriorEquipment:Gas


### PR DESCRIPTION
Added two timeseries outputs for heat rejection end uses in electricity and gas

### Addresses #119 

### Pull Request Description
Added two timeseries outputs for heat rejection end uses in electricity and gas