### PR TITLE
Formatting for web display of rdocs

### DIFF
--- a/lib/urbanopt/scenario/extension.rb
+++ b/lib/urbanopt/scenario/extension.rb
@@ -39,14 +39,15 @@ module URBANopt
       end
 
       ##
-      # Returns the absolute path of the measures or nil if there is none, can be used when configuring OSWs.
+      # [return:] Absolute path of the measures or nil if there is none, can be used when configuring OSWs.
       def measures_dir
         return File.absolute_path(File.join(@root_dir, 'lib', 'measures'))
       end
 
       ##
       # Relevant files such as weather data, design days, etc.
-      # Return the absolute path of the files or nil if there is none, used when configuring OSWs
+      ##
+      # [return:] Absolute path of the files or nil if there is none, used when configuring OSWs
       def files_dir
         return nil
       end
@@ -54,7 +55,8 @@ module URBANopt
       ##
       # Doc templates are common files like copyright files which are used to update measures and other code.
       # Doc templates will only be applied to measures in the current repository.
-      # Return the absolute path of the doc templates dir or nil if there is none.
+      ##
+      # [return:] Absolute path of the doc templates dir or nil if there is none.
       def doc_templates_dir
         return File.absolute_path(File.join(@root_dir, 'doc_templates'))
       end

--- a/lib/urbanopt/scenario/scenario_base.rb
+++ b/lib/urbanopt/scenario/scenario_base.rb
@@ -36,10 +36,10 @@ module URBANopt
       # Initialize ScenarioBase attributes: +name+ , +root directory+ , +run directory+ and +feature_file+
       ##
       # [parameters:]
-      # +name+ - _String_ - Human readable scenario name.
-      # +root_dir+ - _String_ - Root directory for the scenario, contains Gemfile describing dependencies.
-      # +run_dir+ - _String_ - Directory for simulation of this scenario, deleting run directory clears the scenario.
-      # +feature_file+ - _FeatureFile_ - An instance of +URBANopt::Core::FeatureFile+ containing features for simulation.
+      # * +name+ - _String_ - Human readable scenario name.
+      # * +root_dir+ - _String_ - Root directory for the scenario, contains Gemfile describing dependencies.
+      # * +run_dir+ - _String_ - Directory for simulation of this scenario, deleting run directory clears the scenario.
+      # * +feature_file+ - _FeatureFile_ - An instance of +URBANopt::Core::FeatureFile+ containing features for simulation.
       def initialize(name, root_dir, run_dir, feature_file)
         @name = name
         @root_dir = root_dir

--- a/lib/urbanopt/scenario/scenario_csv.rb
+++ b/lib/urbanopt/scenario/scenario_csv.rb
@@ -42,14 +42,13 @@ module URBANopt
       # The CSV file has three columns 1) feature_id, 2) feature_name, and 3) mapper_class_name.  There is one row for each Feature.
       ##
       # [parameters:]
-      # +name+ - _String_ - Human readable scenario name.
-      # +root_dir+ - _String_ - Root directory for the scenario, contains Gemfile describing dependencies.
-      # +run_dir+ - _String_ - Directory for simulation of this scenario, deleting run directory clears the scenario.
-      # +feature_file+ - _URBANopt::Core::FeatureFile_ - FeatureFile containing features to simulate.
-      # +mapper_files_dir+ - _String_ - Directory containing all mapper class files containing MapperBase definitions.
-      # +csv_file+ - _String_ - Path to CSV file assigning a MapperBase class to each feature in feature_file.
-      # +num_header_rows+ - _Strng_ - Number of header rows to skip in CSV file.
-
+      # * +name+ - _String_ - Human readable scenario name.
+      # * +root_dir+ - _String_ - Root directory for the scenario, contains Gemfile describing dependencies.
+      # * +run_dir+ - _String_ - Directory for simulation of this scenario, deleting run directory clears the scenario.
+      # * +feature_file+ - _URBANopt::Core::FeatureFile_ - FeatureFile containing features to simulate.
+      # * +mapper_files_dir+ - _String_ - Directory containing all mapper class files containing MapperBase definitions.
+      # * +csv_file+ - _String_ - Path to CSV file assigning a MapperBase class to each feature in feature_file.
+      # * +num_header_rows+ - _String_ - Number of header rows to skip in CSV file.
       def initialize(name, root_dir, run_dir, feature_file, mapper_files_dir, csv_file, num_header_rows)
         super(name, root_dir, run_dir, feature_file)
         @mapper_files_dir = mapper_files_dir

--- a/lib/urbanopt/scenario/scenario_datapoint_base.rb
+++ b/lib/urbanopt/scenario/scenario_datapoint_base.rb
@@ -38,10 +38,10 @@ module URBANopt
       # A Simulation Mapper will map the
       ##
       # [parameters:]
-      #  +scenario+ - _ScenarioBase_ - Scenario containing this ScenarioDatapoint.
-      #  +feature_id+ - _String_ - Unique id of the feature for this ScenarioDatapoint.
-      #  +feature_name+ - _String_ - Human readable name of the feature for this ScenarioDatapoint.
-      #  +mapper_class+ - _String_ - Name of Ruby class used to translate feature to simulation OSW.
+      # * +scenario+ - _ScenarioBase_ - Scenario containing this ScenarioDatapoint.
+      # * +feature_id+ - _String_ - Unique id of the feature for this ScenarioDatapoint.
+      # * +feature_name+ - _String_ - Human readable name of the feature for this ScenarioDatapoint.
+      # * +mapper_class+ - _String_ - Name of Ruby class used to translate feature to simulation OSW.
       def initialize(scenario, feature_id, feature_name, mapper_class)
         @scenario = scenario
         @feature_id = feature_id

--- a/lib/urbanopt/scenario/scenario_post_processor_base.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_base.rb
@@ -35,7 +35,7 @@ module URBANopt
       # ScenarioPostProcessorBase post-processes a Scenario to create scenario level results.
       ##
       # [parameters:]
-      # +scenario_base+ - _ScenarioBase_ - An object of ScenarioBase class.
+      # * +scenario_base+ - _ScenarioBase_ - An object of ScenarioBase class.
       def initialize(scenario_base)
         @scenario_base = scenario_base
       end
@@ -53,7 +53,7 @@ module URBANopt
       # Add results from a simulation_dir to this result.
       ##
       # [parameters:]
-      # +simulation_dir+ - _SimulationDirOSW_ - An object on SimulationDirOSW class.
+      # * +simulation_dir+ - _SimulationDirOSW_ - An object on SimulationDirOSW class.
       def add_simulation_dir(simulation_dir)
         raise 'add_simulation_dir not implemented for ScenarioPostProcessorBase, override in your class'
       end

--- a/lib/urbanopt/scenario/scenario_post_processor_default.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_default.rb
@@ -43,7 +43,7 @@ module URBANopt
       # ScenarioPostProcessorBase post-processes a scenario to create scenario level results
       ##
       # [parameters:]
-      # +scenario_base+ - _ScenarioBase_ - An object of ScenarioBase class.
+      # * +scenario_base+ - _ScenarioBase_ - An object of ScenarioBase class.
       def initialize(scenario_base)
         super(scenario_base)
 
@@ -69,7 +69,7 @@ module URBANopt
       # Add results from a simulation_dir to this result.
       ##
       # [parameters:]
-      # +simulation_dir+ - _SimulationDirOSW_ - An object on SimulationDirOSW class.
+      # * +simulation_dir+ - _SimulationDirOSW_ - An object on SimulationDirOSW class.
       def add_simulation_dir(simulation_dir)
         feature_reports = URBANopt::Reporting::DefaultReports::FeatureReport.from_simulation_dir(simulation_dir)
 
@@ -86,6 +86,9 @@ module URBANopt
 
       # Create database file with scenario-level results
       #   Sum values for each timestep across all features. Save to new table in a new database
+      ##
+      # [parameters:]
+      # * +file_name+ - _String_ - Assign a name to the saved scenario results file
       def create_scenario_db_file(file_name = @default_save_name)
         new_db_file = File.join(@initialization_hash[:directory_name], "#{file_name}.db")
         scenario_db = SQLite3::Database.open new_db_file
@@ -192,7 +195,7 @@ module URBANopt
       # Save scenario result
       ##
       # [parameters:]
-      # +file_name+ - _String_ - Assign a name to the saved scenario results file
+      # * +file_name+ - _String_ - Assign a name to the saved scenario results file
       def save(file_name = @default_save_name)
         @scenario_result.save
 

--- a/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
@@ -43,8 +43,8 @@ module URBANopt
       # OpenDSSPostProcessor post-processes OpenDSS results to selected OpenDSS results and integrate them in scenario and feature reports.
       ##
       # [parameters:]
-      # +scenario_report+ - _ScenarioBase_ - An object of Scenario_report class.
-      # +opendss_results_dir_name+ - _directory name of opendss results
+      # * +scenario_report+ - _ScenarioBase_ - An object of Scenario_report class.
+      # * +opendss_results_dir_name+ - _directory name of opendss results
       def initialize(scenario_report, opendss_results_dir_name = 'opendss')
         if !scenario_report.nil?
           @scenario_report = scenario_report
@@ -202,9 +202,9 @@ module URBANopt
       # Save csv report method
       ##
       # [parameters:]
-      # +feature_report+ - _feature report object_ - An onject of the feature report
-      # +updated_feature_report_csv+ - _CSV_ - An updated feature report csv
-      # +file_name+ - _String_ - Assigned name to save the file with no extension
+      # * +feature_report+ - _feature report object_ - An onject of the feature report
+      # * +updated_feature_report_csv+ - _CSV_ - An updated feature report csv
+      # * +file_name+ - _String_ - Assigned name to save the file with no extension
       def save_csv(feature_report, updated_feature_report_csv, file_name = 'default_feature_report')
         File.write(File.join(feature_report.directory_name, 'feature_reports', "#{file_name}.csv"), updated_feature_report_csv)
       end
@@ -213,7 +213,7 @@ module URBANopt
       # create opendss json report results
       ##
       # [parameters:]
-      # +feature_report+ - _feature report object_ - An onject of the feature report
+      # * +feature_report+ - _feature report object_ - An onject of the feature report
       def add_summary_results(feature_report)
         under_voltage_hrs = 0
         over_voltage_hrs = 0

--- a/lib/urbanopt/scenario/scenario_runner_base.rb
+++ b/lib/urbanopt/scenario/scenario_runner_base.rb
@@ -40,8 +40,9 @@ module URBANopt
       # Create all SimulationDirs for Scenario.
       ##
       # [parameters:]
-      # +scenario+ - _ScenarioBase_ - Scenario to create simulation input files for scenario.
-      # +force_clear+ - _Bool_ - Clear Scenario before creating simulation input files
+      # * +scenario+ - _ScenarioBase_ - Scenario to create simulation input files for scenario.
+      # * +force_clear+ - _Bool_ - Clear Scenario before creating simulation input files
+      ##
       # [return:] _Array_ Returns an array of all SimulationDirs, even those created previously, for Scenario.
       def create_simulation_files(scenario, force_clear = false)
         raise 'create_input_files is not implemented for ScenarioRunnerBase, override in your class'
@@ -51,9 +52,9 @@ module URBANopt
       # Create and run all SimulationFiles for Scenario.
       ##
       # [parameters:]
-      # +scenario+ - _ScenarioBase_ - Scenario to create and run simulation input files for.
-      # +force_clear+ - _Bool_ - Clear Scenario before creating Simulation input files.
-      #
+      # * +scenario+ - _ScenarioBase_ - Scenario to create and run simulation input files for.
+      # * +force_clear+ - _Bool_ - Clear Scenario before creating Simulation input files.
+      ##
       # [return:] _Array_ Returns an array of all SimulationDirs, even those created previously, for Scenario.
       def run(scenario, force_clear = false, options = {})
         raise 'run is not implemented for ScenarioRunnerBase, override in your class'

--- a/lib/urbanopt/scenario/scenario_runner_osw.rb
+++ b/lib/urbanopt/scenario/scenario_runner_osw.rb
@@ -46,8 +46,9 @@ module URBANopt
       # Create all OSWs for Scenario.
       ##
       # [parameters:]
-      # +scenario+ - _ScenarioBase_ - Scenario to create simulation input files for.
-      # +force_clear+ - _Bool_ - Clear Scenario before creating simulation input files.
+      # * +scenario+ - _ScenarioBase_ - Scenario to create simulation input files for.
+      # * +force_clear+ - _Bool_ - Clear Scenario before creating simulation input files.
+      ##
       # [return:] _Array_ Returns array of all SimulationDirs, even those created previously, for Scenario.
       def create_simulation_files(scenario, force_clear = false)
         if force_clear
@@ -79,8 +80,9 @@ module URBANopt
       # - Run osw file groups in order and store simulation failure in a array.
       ##
       # [parameters:]
-      # +scenario+ - _ScenarioBase_ - Scenario to create and run SimulationFiles for.
-      # +force_clear+ - _Bool_ - Clear Scenario before creating SimulationFiles.
+      # * +scenario+ - _ScenarioBase_ - Scenario to create and run SimulationFiles for.
+      # * +force_clear+ - _Bool_ - Clear Scenario before creating SimulationFiles.
+      ##
       # [return:] _Array_ Returns array of all SimulationFiles, even those created previously, for Scenario.
       def run(scenario, force_clear = false, options = {})
         # instantiate openstudio runner - use the defaults for now. If need to change then create

--- a/lib/urbanopt/scenario/simulation_dir_base.rb
+++ b/lib/urbanopt/scenario/simulation_dir_base.rb
@@ -35,9 +35,9 @@ module URBANopt
       # SimulationDirBase is the agnostic representation of a directory of simulation input files.
       ##
       # [parameters:]
-      # +scenario+ - _ScenarioBase_ - Scenario containing this SimulationDirBase.
-      # +features+ - _Array_ - Array of Features that this SimulationDirBase represents.
-      # +feature_names+ - _Array_ - Array of scenario specific names for these Features.
+      # * +scenario+ - _ScenarioBase_ - Scenario containing this SimulationDirBase.
+      # * +features+ - _Array_ - Array of Features that this SimulationDirBase represents.
+      # * +feature_names+ - _Array_ - Array of scenario specific names for these Features.
       def initialize(scenario, features, feature_names)
         @scenario = scenario
         @features = features

--- a/lib/urbanopt/scenario/simulation_dir_osw.rb
+++ b/lib/urbanopt/scenario/simulation_dir_osw.rb
@@ -37,10 +37,10 @@ module URBANopt
       # SimulationDirOSW creates a OSW file to simulate features, a SimulationMapperBase is invoked to translate features to OSW.
       ##
       # [parameters:]
-      # +scenario+ - _ScenarioBase_ - Scenario containing this SimulationFileBase.
-      # +features+ - _Array_ - Array of Features this SimulationFile represents.
-      # +feature_names+ - _Array_ - Array of scenario specific names for these Features.
-      # +mapper_class+ - _String_ - Name of class derived frmo SimulationMapperBase used to translate feature to simulation OSW.
+      # * +scenario+ - _ScenarioBase_ - Scenario containing this SimulationFileBase.
+      # * +features+ - _Array_ - Array of Features this SimulationFile represents.
+      # * +feature_names+ - _Array_ - Array of scenario specific names for these Features.
+      # * +mapper_class+ - _String_ - Name of class derived frmo SimulationMapperBase used to translate feature to simulation OSW.
       def initialize(scenario, features, feature_names, mapper_class)
         super(scenario, features, feature_names)
 

--- a/lib/urbanopt/scenario/simulation_mapper_base.rb
+++ b/lib/urbanopt/scenario/simulation_mapper_base.rb
@@ -36,9 +36,9 @@ module URBANopt
 
       # create osw file given a ScenarioBase object, features, and feature_names
       # [parameters:]
-      # +scenario+ - _ScenarioBase_ - An object of ScenarioBase class.
-      # +features+ - _Array_ - Array of Features.
-      # +feature_names+ - _Array_ - Array of scenario specific names for these Features.
+      # * +scenario+ - _ScenarioBase_ - An object of ScenarioBase class.
+      # * +features+ - _Array_ - Array of Features.
+      # * +feature_names+ - _Array_ - Array of scenario specific names for these Features.
       def create_osw(scenario, features, feature_names)
         raise 'create_osw not implemented for SimulationMapperBase, override in your class'
       end


### PR DESCRIPTION
### Resolves #60 

### Pull Request Description

Put method parameter documentation into markdown lists, so rdoc formats them properly for web viewing.

### Checklist (Delete lines that don't apply)

- [x] Documentation has been modified as needed
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-scenario-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
