### PR TITLE
only use years after 1900 in query

### DIFF
--- a/lib/urbanopt/scenario/scenario_post_processor_default.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_default.rb
@@ -138,6 +138,7 @@ module URBANopt
           INNER JOIN ReportDataDictionary AS rddi ON rddi.ReportDataDictionaryIndex=ReportData.ReportDataDictionaryIndex
           WHERE rddi.IndexGroup == 'Facility:Electricity'
           AND rddi.ReportingFrequency == 'Zone Timestep'
+          AND Time.Year > 1900
           ORDER BY ReportData.TimeIndex"
 
           elec_query.each do |row| # Add up all the values for electricity usage across all Features at this timestep
@@ -161,6 +162,7 @@ module URBANopt
           INNER JOIN ReportDataDictionary AS rddi ON rddi.ReportDataDictionaryIndex=ReportData.ReportDataDictionaryIndex
           WHERE rddi.IndexGroup == 'Facility:Gas'
           AND rddi.ReportingFrequency == 'Zone Timestep'
+          AND Time.Year > 1900
           ORDER BY ReportData.TimeIndex"
 
           gas_query.each do |row|


### PR DESCRIPTION
### Resolves #170 

### Pull Request Description
Limits results of the sql query to exclude years <= 1900

### Checklist (Delete lines that don't apply)

- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-scenario-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
