### PR TITLE
opendss postprocessor: update scenario reports saving method to not save the feature reports.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-reporting-gem')
 #  gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
 # elsif allow_local
-#  gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
+  gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
 # end
 
 # if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')

--- a/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
@@ -267,6 +267,7 @@ module URBANopt
         save_transformers_reports
 
         # save the updated scenario reports
+        # set save_feature_reports to false since only the scenario reports should be saved now
         @scenario_report.save(file_name = 'scenario_report_opendss', save_feature_reports = false)
       end
     end

--- a/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
@@ -267,7 +267,7 @@ module URBANopt
         save_transformers_reports
 
         # save the updated scenario reports
-        @scenario_report.save(file_name = 'scenario_report_opendss')
+        @scenario_report.save(file_name = 'scenario_report_opendss', save_feature_reports = false)
       end
     end
   end

--- a/spec/files/Gemfile
+++ b/spec/files/Gemfile
@@ -26,13 +26,13 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # end
 #
 
-if allow_local && File.exist?('../../../urbanopt-reporting-gem')
-  gem 'urbanopt-reporting', path: '../../../urbanopt-reporting-gem'
-elsif allow_local
+#if allow_local && File.exist?('../../../urbanopt-reporting-gem')
+#  gem 'urbanopt-reporting', path: '../../../urbanopt-reporting-gem'
+#elsif allow_local
   gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
-else
-  gem 'urbanopt-reporting', '~> 0.3.2'
-end
+#else
+#  gem 'urbanopt-reporting', '~> 0.3.2'
+#end
 
 if allow_local && File.exist?('../../../openstudio-common-measures-gem')
   gem 'openstudio-common-measures', path: '../../../openstudio-common-measures-gem'


### PR DESCRIPTION
### Resolves #196 

### Pull Request Description
opendss postprocessor: update scenario reports saving method to not save the feature reports.
set save_feature_reports argument to false in the 'run' method of the opendss postprocessor
