### PR TITLE
Update Load-Flex measure gem version

### DIFF
--- a/urbanopt-scenario-gem.gemspec
+++ b/urbanopt-scenario-gem.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'openstudio-calibration', '~> 0.3.1'
   spec.add_runtime_dependency 'openstudio-common-measures', '~> 0.3.2'
   spec.add_runtime_dependency 'openstudio-ee', '~> 0.3.2'
-  spec.add_runtime_dependency 'openstudio-load-flexibility-measures', '~> 0.3.0'
+  spec.add_runtime_dependency 'openstudio-load-flexibility-measures', '~> 0.3.1'
   spec.add_runtime_dependency 'openstudio-model-articulation', '~> 0.3.1'
 end

--- a/urbanopt-scenario-gem.gemspec
+++ b/urbanopt-scenario-gem.gemspec
@@ -42,6 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'openstudio-calibration', '~> 0.3.1'
   spec.add_runtime_dependency 'openstudio-common-measures', '~> 0.3.2'
   spec.add_runtime_dependency 'openstudio-ee', '~> 0.3.2'
-  spec.add_runtime_dependency 'openstudio-load-flexibility-measures', '~> 0.2.1'
+  spec.add_runtime_dependency 'openstudio-load-flexibility-measures', '~> 0.3.0'
   spec.add_runtime_dependency 'openstudio-model-articulation', '~> 0.3.1'
 end


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

Updates the openstudio-load-flexibility-measures gem dependency to version 0.3.1, which has been tested with the latest OpenStudio 3.2-alpha release and is upgraded to Ruby v. 2.7.

### Checklist (Delete lines that don't apply)
