### PR TITLE
remove scenario-file (as a whole) from checks to re-run datapoints

### DIFF
--- a/lib/urbanopt/scenario/simulation_dir_osw.rb
+++ b/lib/urbanopt/scenario/simulation_dir_osw.rb
@@ -174,9 +174,6 @@ module URBANopt
         # depends on the feature file
         dependencies << scenario.feature_file.path
 
-        # depends on the csv file
-        dependencies << scenario.csv_file
-
         # depends on the mapper classes
         Dir.glob(File.join(scenario.mapper_files_dir, '*')).each do |f|
           dependencies << f


### PR DESCRIPTION
### Resolves [CLI issue 237](https://github.com/urbanopt/urbanopt-cli/issues/237)

### Pull Request Description
The change in this PR means changes to the scenario-file do not trigger re-running every datapoint (removes it from the 2nd list below).

#### Documenting out-of-date datapoints:
[This check](https://github.com/urbanopt/urbanopt-scenario-gem/blob/develop/lib/urbanopt/scenario/simulation_dir_osw.rb#L151-L164) looks inside each datapoint specified in the scenario-file.
- If one of the datapoints does not have a `finished.job` file or an `out.osw` file, it is re-run
- If the datapoint folder doesn't exist, it is re-run

If the [most recent change to any out.osw file](https://github.com/urbanopt/urbanopt-scenario-gem/blob/develop/lib/urbanopt/scenario/simulation_dir_osw.rb#L165) is older than the most recent change to any of the following project-dir files, the entire scenario is re-run.
- `in.osw`
- feature file
- `Gemfile`
- `Gemfile.lock`
- Anything inside the `mappers` folder

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified as needed
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-scenario-gem/issues) has been created (which will be used for the changelog)
- [ ] This branch is up-to-date with develop
