### PR TITLE
Qaqc visualizing

### DIFF
--- a/lib/urbanopt/scenario/scenario_visualization.rb
+++ b/lib/urbanopt/scenario/scenario_visualization.rb
@@ -45,10 +45,10 @@ require 'json'
 module URBANopt
   module Scenario
     class ResultVisualization
-      def self.create_visualization(run_dir, feature = true, feature_names = false)
+      def self.create_visualization(default_report_list, feature = true, feature_names = false)
         @all_results = []
         name = nil
-        run_dir.each do |folder|
+        default_report_list.each do |folder|
           # create visualization for scenarios
           case feature
           when false
@@ -57,7 +57,7 @@ module URBANopt
 
           # create visualization for features
           when true
-            index = run_dir.index(folder)
+            index = default_report_list.index(folder)
             name = "#{folder.split('/')[-3]}-#{feature_names[index]}"
             csv_dir = folder
           end
@@ -241,15 +241,15 @@ module URBANopt
         flag_aggregation = { 'QAQC category': 'Total number of flags' } # Make a hash for count of flags of each category for this scenario
         # This if-tree gets us to the run_dir from the default_report handed to the method
         # FIXME: this is soooo brittle it makes me sad
-        if run_dir[0].to_s.end_with?('scenario')
+        if default_report_list[0].to_s.end_with?('scenario')
           # Handles cases where the run dir is passed straight in - might not ever happen?
-          scenario_run_dir = Pathname.new(run_dir[0])
-        elsif Pathname.new(run_dir[0]).parent.to_s.end_with?('scenario')
+          scenario_run_dir = Pathname.new(default_report_list[0])
+        elsif Pathname.new(default_report_list[0]).parent.to_s.end_with?('scenario')
           # For scenario visualization
-          scenario_run_dir = Pathname.new(run_dir[0])
-        elsif Pathname.new(run_dir[0]).parent.parent.parent.to_s.end_with?('scenario')
+          scenario_run_dir = Pathname.new(default_report_list[0])
+        elsif Pathname.new(default_report_list[0]).parent.parent.parent.to_s.end_with?('scenario')
           # For feature visualization
-          scenario_run_dir = Pathname.new(run_dir[0]).parent.parent
+          scenario_run_dir = Pathname.new(default_report_list[0]).parent.parent
         end
         dirs_in_scenario = scenario_run_dir.parent.children.select(&:directory?)
         # This will occasionally pick up the opendss folder or similar, but the 'next unless' line will skip that dir for us
@@ -277,10 +277,10 @@ module URBANopt
         # create json with required data stored in a variable
         if feature == false
           # In case of scenario visualization store result at top of the run folder
-          results_path = File.expand_path('../../scenarioData.js', run_dir[0])
+          results_path = File.expand_path('../../scenarioData.js', default_report_list[0])
         else
           # In case of feature visualization store result at top of scenario folder folder
-          results_path = File.expand_path('../../../scenarioData.js', run_dir[0])
+          results_path = File.expand_path('../../../scenarioData.js', default_report_list[0])
         end
         File.open(results_path, 'w') do |file|
           file << "var scenarioData = #{JSON.pretty_generate(@all_results)};"

--- a/lib/urbanopt/scenario/scenario_visualization.rb
+++ b/lib/urbanopt/scenario/scenario_visualization.rb
@@ -262,6 +262,11 @@ module URBANopt
                 end
               end
             end
+            # FIXME: Filthy hack to put 'total_qaqc_flags' at the end of the hash
+            # Purpose is to make it look reasonable when displayed in visualization html report
+            temp_hash_for_ordering = { 'total_qaqc_flags' => flag_aggregation['total_qaqc_flags'] }
+            flag_aggregation.delete('total_qaqc_flags')
+            flag_aggregation['total_qaqc_flags'] = temp_hash_for_ordering['total_qaqc_flags']
             results['qaqc_flags'] = flag_aggregation
           end
 

--- a/lib/urbanopt/scenario/scenario_visualization.rb
+++ b/lib/urbanopt/scenario/scenario_visualization.rb
@@ -237,6 +237,43 @@ module URBANopt
           end
         end
 
+        # QAQC flags by category
+        flag_aggregation = { 'QAQC category': 'Total number of flags' } # Make a hash for count of flags of each category for this scenario
+        # This if-tree gets us to the run_dir from the default_report handed to the method
+        # FIXME: this is soooo brittle it makes me sad
+        if run_dir[0].to_s.end_with?('scenario')
+          # Handles cases where the run dir is passed straight in - might not ever happen?
+          scenario_run_dir = Pathname.new(run_dir[0])
+        elsif Pathname.new(run_dir[0]).parent.to_s.end_with?('scenario')
+          # For scenario visualization
+          scenario_run_dir = Pathname.new(run_dir[0])
+        elsif Pathname.new(run_dir[0]).parent.parent.parent.to_s.end_with?('scenario')
+          # For feature visualization
+          scenario_run_dir = Pathname.new(run_dir[0]).parent.parent
+        end
+        dirs_in_scenario = scenario_run_dir.parent.children.select(&:directory?)
+        # This will occasionally pick up the opendss folder or similar, but the 'next unless' line will skip that dir for us
+        dirs_in_scenario.each do |dir_in_scenario| # Go through the list of features in the scenario
+          next unless File.file?(File.join(dir_in_scenario, 'out.osw')) # skip if osw doesn't exist - needed because scenario-gem testing doesn't have osw's
+
+          osw = JSON.parse(File.read(File.join(dir_in_scenario, 'out.osw'))) # Get the qaqc measure data from out.osw
+          osw['steps'].each do |step| # Go through the list of steps in out.osw
+            next unless step['measure_dir_name'] == 'generic_qaqc'
+
+            step['result']['step_values'].each do |step_value| # Go through the list of step values in qaqc
+              if step_value['units'] == 'flags' && step_value['value'] > 0 # Find categories with flags
+                # If the category has already been made in the flag hash, add to it; otherwise create the category and populate it
+                if flag_aggregation[step_value['name']]
+                  flag_aggregation[step_value['name']] += step_value['value']
+                else flag_aggregation[step_value['name']] = step_value['value']
+                end
+              end
+            end
+          end
+        end
+
+        @all_results << flag_aggregation
+
         # create json with required data stored in a variable
         if feature == false
           # In case of scenario visualization store result at top of the run folder

--- a/lib/urbanopt/scenario/scenario_visualization.rb
+++ b/lib/urbanopt/scenario/scenario_visualization.rb
@@ -45,7 +45,7 @@ require 'json'
 module URBANopt
   module Scenario
     class ResultVisualization
-      def self.create_visualization(run_dir, feature = true, feature_names = false)
+      def self.create_visualization(run_dir, feature: true, feature_names: false)
         @all_results = []
         name = nil
         run_dir.each do |folder|
@@ -112,9 +112,9 @@ module URBANopt
             dec_date = DateTime.new(year.to_i, 12, 1, 0, 0)
             jan_next_year = DateTime.new(year.to_i + 1, 1, 1, 0, 0)
 
-            monthly_values['Datetime'].each do |i|
-              date_obj = DateTime.strptime(i.to_s, format)
-              index = monthly_values['Datetime'].index(i)
+            monthly_values['Datetime'].each do |date|
+              date_obj = DateTime.strptime(date.to_s, format)
+              index = monthly_values['Datetime'].index(date)
 
               # store index of each date from the csv
               if feb_date == date_obj

--- a/lib/urbanopt/scenario/scenario_visualization.rb
+++ b/lib/urbanopt/scenario/scenario_visualization.rb
@@ -45,7 +45,7 @@ require 'json'
 module URBANopt
   module Scenario
     class ResultVisualization
-      def self.create_visualization(run_dir, feature: true, feature_names: false)
+      def self.create_visualization(run_dir, feature = true, feature_names = false)
         @all_results = []
         name = nil
         run_dir.each do |folder|
@@ -112,9 +112,9 @@ module URBANopt
             dec_date = DateTime.new(year.to_i, 12, 1, 0, 0)
             jan_next_year = DateTime.new(year.to_i + 1, 1, 1, 0, 0)
 
-            monthly_values['Datetime'].each do |date|
-              date_obj = DateTime.strptime(date.to_s, format)
-              index = monthly_values['Datetime'].index(date)
+            monthly_values['Datetime'].each do |i|
+              date_obj = DateTime.strptime(i.to_s, format)
+              index = monthly_values['Datetime'].index(i)
 
               # store index of each date from the csv
               if feb_date == date_obj

--- a/spec/urbanopt/urbanopt_scenario_reports_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_reports_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe URBANopt::Reporting::DefaultReports do
 
     json_file = JSON.parse(visualization_file)
     # order does not seem to be the same, but ensure they both made it in the results file
-    if (json_file.size == 3) && ['1-Building_1', '2-Building_2'].include?(json_file[0]['name']) && ['1-Building_1', '2-Building_2'].include?(json_file[1]['name'])
+    if (json_file.size == 2) && ['1-Building_1', '2-Building_2'].include?(json_file[0]['name']) && ['1-Building_1', '2-Building_2'].include?(json_file[1]['name'])
       test_name = true
     else
       test_name = false

--- a/spec/urbanopt/urbanopt_scenario_reports_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_reports_spec.rb
@@ -270,11 +270,11 @@ RSpec.describe URBANopt::Reporting::DefaultReports do
     json_file = JSON.parse(visualization_file)
     # order does not seem to be the same, but ensure they both made it in the results file
     if (json_file.size == 3) && ['1-Building_1', '2-Building_2'].include?(json_file[0]['name']) && ['1-Building_1', '2-Building_2'].include?(json_file[1]['name'])
-      testName = true
+      test_name = true
     else
-      testName = false
+      test_name = false
     end
-    expect(testName).to be_truthy
+    expect(test_name).to be_truthy
 
     expect(json_file[0]['monthly_values']['Electricity:Facility'].size).to eq 12
     if json_file[0]['name'] == '1-Building_1'

--- a/spec/urbanopt/urbanopt_scenario_reports_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_reports_spec.rb
@@ -234,9 +234,9 @@ RSpec.describe URBANopt::Reporting::DefaultReports do
   end
 
   it 'can create visualization for scenario result' do
-    run_dir = [File.join(File.dirname(__FILE__), '../vis_test/baseline_scenario/default_scenario_report.csv')]
-    scenario_visualization = URBANopt::Scenario::ResultVisualization.create_visualization(run_dir, false)
-    file = File.expand_path('../../scenarioData.js', run_dir[0])
+    default_report_list = [File.join(File.dirname(__FILE__), '../vis_test/baseline_scenario/default_scenario_report.csv')]
+    scenario_visualization = URBANopt::Scenario::ResultVisualization.create_visualization(default_report_list, false)
+    file = File.expand_path('../../scenarioData.js', default_report_list[0])
 
     expect(File.exist?(file)).to be true
 
@@ -254,12 +254,12 @@ RSpec.describe URBANopt::Reporting::DefaultReports do
   end
 
   it 'can create visualization for feature result' do
-    run_dir = [File.join(File.dirname(__FILE__), '../vis_test/baseline_scenario/1/feature_reports/default_feature_report.csv'), File.join(File.dirname(__FILE__), '../vis_test/baseline_scenario/2/feature_reports/default_feature_report.csv')]
+    default_report_list = [File.join(File.dirname(__FILE__), '../vis_test/baseline_scenario/1/feature_reports/default_feature_report.csv'), File.join(File.dirname(__FILE__), '../vis_test/baseline_scenario/2/feature_reports/default_feature_report.csv')]
     feature_names = ['Building_1', 'Building_2']
 
-    scenario_visualization = URBANopt::Scenario::ResultVisualization.create_visualization(run_dir, true, feature_names)
+    scenario_visualization = URBANopt::Scenario::ResultVisualization.create_visualization(default_report_list, true, feature_names)
 
-    file = File.expand_path('../../../scenarioData.js', run_dir[0])
+    file = File.expand_path('../../../scenarioData.js', default_report_list[0])
     expect(File.exist?(file)).to be true
 
     visualization_file = File.read(file)

--- a/spec/urbanopt/urbanopt_scenario_reports_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_reports_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe URBANopt::Reporting::DefaultReports do
 
     json_file = JSON.parse(visualization_file)
     # order does not seem to be the same, but ensure they both made it in the results file
-    if (json_file.size == 2) && ['1-Building_1', '2-Building_2'].include?(json_file[0]['name']) && ['1-Building_1', '2-Building_2'].include?(json_file[1]['name'])
+    if (json_file.size == 3) && ['1-Building_1', '2-Building_2'].include?(json_file[0]['name']) && ['1-Building_1', '2-Building_2'].include?(json_file[1]['name'])
       testName = true
     else
       testName = false


### PR DESCRIPTION
### Resolves https://github.com/urbanopt/urbanopt-reporting-gem/issues/107

### Pull Request Description

Reads output from QAQC measure and aggregates into the scenarioData.js file for use in visualization.

### To test manually:
- Change the cli gemfile to look at this branch - `qaqc-visualizing`
- Make a new default SDK project
- Enable qaqc measure in <new_project_dir>/mappers/base_workflow.osw
- Run, default-process a new project using the newest version of the cli
- Call the visualize command from the uo cli, using the `-f` flag, not the `-s` flag
- Inspect the very last hash in scenarioData.js

**_Running the scenario-gem test will not exercise most of this code as no osw files are present in the scenario-gem test data_**

## Todo:
- [ ] Make pretty table from hash in scenarioData.js
- [ ] Add link (links?) to QAQC reports that are inside each feature

### Checklist (Delete lines that don't apply)

- [x] Unit tests have been added or updated
- [ ] Documentation has been modified as needed
- [x] All ci tests pass (green)
- [x] An [issue](https://github.com/urbanopt/urbanopt-scenario-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
