### PR TITLE
pin addressable dependency

### DIFF
--- a/spec/files/Gemfile
+++ b/spec/files/Gemfile
@@ -26,6 +26,8 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # end
 #
 
+gem 'addressable', '2.8.1'
+
 if allow_local && File.exist?('../openstudio-common-measures-gem')
   gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 elsif allow_local


### PR DESCRIPTION
An unpinned dependency 'addressable' in the project gemfile caused run errors.  Pinning the dependency should fix the tests in this repo.