### PR TITLE
Add transformer in- and out-going voltages to reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,9 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # end
 
 # if allow_local && File.exist?('../urbanopt-reporting-gem')
-#  gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
+# gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
 # elsif allow_local
-# gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
+gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'transformers'
 # end
 
 # if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-reporting-gem')
 # gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
 # elsif allow_local
-gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'transformers'
+gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
 # end
 
 # if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')

--- a/lib/urbanopt/scenario/scenario_post_processor_disco.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_disco.rb
@@ -10,115 +10,106 @@ require 'json'
 require 'fileutils'
 
 module URBANopt
-    module Scenario
-        class DISCOPostProcessor
-            ##
-            # DISCOPostProcessor post-processes DISCO results to selected DISCO results and
-            # integrate them in scenario and feature reports.
-            ##
-            # [parameters:]
-            # * +scenaro_report+ - _ScenarioBase_ - An object of Scenario_report class.
-            # * +disco_results_dir_name+ - _directory name of disco results
-            def initialize(scenario_report, disco_results_dir_name = 'disco')
-                if !scenario_report.nil?
-                    @scenario_report = scenario_report
-                    @disco_results_dir = File.join(@scenario_report.directory_name, disco_results_dir_name)
-                else
-                    raise 'scenario_report is not valid'
-                end
-
-                # initialize disco data
-                @disco_data = {}
-
-                # initialize disco json results
-                @disco_json_results = {}
-
-                # initialize logger
-                @@logger ||= URBANopt::Reporting::DefaultReports.logger
-            end
-
-            # load disco data (if exists)
-            def load_disco_data
-
-                # load disco upgrade summary
-                disco_json_filename = File.join(@disco_results_dir, 'upgrade_summary.json')
-                if File.exist?(disco_json_filename)
-                    @disco_json_results = JSON.parse(File.read(disco_json_filename))
-                end
-
-            end
-
-            # load disco data
-            def load_data
-                # load selected disco data
-                load_disco_data
-            end
-
-
-            ##
-            # save disco scenario fields
-            ##
-            def save_disco_scenario
-                @scenario_report.scenario_power_distribution_cost = URBANopt::Reporting::DefaultReports::ScenarioPowerDistributionCost.new
-
-                # RESULTS
-
-                res = []
-                # read result from JSON report
-                res = @disco_json_results['results']
-                @scenario_report.scenario_power_distribution_cost.results = res
-
-
-
-                # OUTPUTS
-
-                out = {}
-                # read result from JSON report
-                out[:log_file] = @disco_json_results['outputs']['log_file']
-                out[:jobs] = []
-                @disco_json_results['outputs']['jobs'].each do |job|
-                    out[:jobs] << job
-                end
-                @scenario_report.scenario_power_distribution_cost.outputs = out
-
-                # VIOLATION SUMMARY
-
-                vio = []
-                # read result from JSON report
-                vio = @disco_json_results['violation_summary']
-                @scenario_report.scenario_power_distribution_cost.violation_summary = vio
-
-                # COSTS PER EQUIPMENT
-                cos = []
-                # read result from JSON report
-                cos = @disco_json_results['costs_per_equipment']
-                @scenario_report.scenario_power_distribution_cost.costs_per_equipment = cos
-
-                # EQUIPMENT
-                equ = []
-                # read result from JSON report
-                equ = @disco_json_results['equipment']
-                @scenario_report.scenario_power_distribution_cost.equipment = equ
-
-            end
-            
-            ##
-            # run disco post_processor
-            ##
-            def run
-
-                # load data
-                load_data
-
-                # save additional global disco fields
-                save_disco_scenario
-
-                # save the updated scenario reports
-                # set save_feature_reports to false since only the scenario reports should be saved
-                # now, set save csv reports to false
-                @scenario_report.save(file_name = 'scenario_report_disco', save_feature_reports = false, save_csv_reports = false)
-            end
-
+  module Scenario
+    class DISCOPostProcessor
+      ##
+      # DISCOPostProcessor post-processes DISCO results to selected DISCO results and
+      # integrate them in scenario and feature reports.
+      ##
+      # [parameters:]
+      # * +scenaro_report+ - _ScenarioBase_ - An object of Scenario_report class.
+      # * +disco_results_dir_name+ - _directory name of disco results
+      def initialize(scenario_report, disco_results_dir_name = 'disco')
+        if !scenario_report.nil?
+          @scenario_report = scenario_report
+          @disco_results_dir = File.join(@scenario_report.directory_name, disco_results_dir_name)
+        else
+          raise 'scenario_report is not valid'
         end
+
+        # initialize disco data
+        @disco_data = {}
+
+        # initialize disco json results
+        @disco_json_results = {}
+
+        # initialize logger
+        @@logger ||= URBANopt::Reporting::DefaultReports.logger
+      end
+
+      # load disco data (if exists)
+      def load_disco_data
+        # load disco upgrade summary
+        disco_json_filename = File.join(@disco_results_dir, 'upgrade_summary.json')
+        if File.exist?(disco_json_filename)
+          @disco_json_results = JSON.parse(File.read(disco_json_filename))
+        end
+      end
+
+      # load disco data
+      def load_data
+        # load selected disco data
+        load_disco_data
+      end
+
+      ##
+      # save disco scenario fields
+      ##
+      def save_disco_scenario
+        @scenario_report.scenario_power_distribution_cost = URBANopt::Reporting::DefaultReports::ScenarioPowerDistributionCost.new
+
+        # RESULTS
+
+        res = []
+        # read result from JSON report
+        res = @disco_json_results['results']
+        @scenario_report.scenario_power_distribution_cost.results = res
+
+        # OUTPUTS
+
+        out = {}
+        # read result from JSON report
+        out[:log_file] = @disco_json_results['outputs']['log_file']
+        out[:jobs] = []
+        @disco_json_results['outputs']['jobs'].each do |job|
+          out[:jobs] << job
+        end
+        @scenario_report.scenario_power_distribution_cost.outputs = out
+
+        # VIOLATION SUMMARY
+
+        vio = []
+        # read result from JSON report
+        vio = @disco_json_results['violation_summary']
+        @scenario_report.scenario_power_distribution_cost.violation_summary = vio
+
+        # COSTS PER EQUIPMENT
+        cos = []
+        # read result from JSON report
+        cos = @disco_json_results['costs_per_equipment']
+        @scenario_report.scenario_power_distribution_cost.costs_per_equipment = cos
+
+        # EQUIPMENT
+        equ = []
+        # read result from JSON report
+        equ = @disco_json_results['equipment']
+        @scenario_report.scenario_power_distribution_cost.equipment = equ
+      end
+
+      ##
+      # run disco post_processor
+      ##
+      def run
+        # load data
+        load_data
+        # save additional global disco fields
+        save_disco_scenario
+
+        # save the updated scenario reports
+        # set save_feature_reports to false since only the scenario reports should be saved
+        # now, set save csv reports to false
+        @scenario_report.save(file_name = 'scenario_report_disco', save_feature_reports = false, save_csv_reports = false)
+      end
     end
+  end
 end

--- a/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
@@ -171,9 +171,13 @@ module URBANopt
             over_voltage_hrs = 0
             nominal_capacity = nil
             r_r_ratio = nil
+            tx_incoming_voltage = nil
+            tx_outgoing_voltage = nil
             begin
               nominal_capacity = t_res[t_key][:nominal_capacity]
               r_r_ratio = t_res[t_key][:reactance_resistance_ratio]
+              tx_incoming_voltage = t_res[t_key][:incoming_voltage]
+              tx_outgoing_voltage = t_res[t_key][:outgoing_voltage]
             rescue StandardError
             end
 
@@ -206,8 +210,8 @@ module URBANopt
             transformer_report.power_distribution.under_voltage_hours = under_voltage_hrs
             transformer_report.power_distribution.nominal_capacity = nominal_capacity
             transformer_report.power_distribution.reactance_resistance_ratio = r_r_ratio
-            transformer_report.power_distribution.tx_incoming_voltage = t_res[t_key][:incoming_voltage]
-            transformer_report.power_distribution.tx_outgoing_voltage = t_res[t_key][:outgoing_voltage]
+            transformer_report.power_distribution.tx_incoming_voltage = tx_incoming_voltage
+            transformer_report.power_distribution.tx_outgoing_voltage = tx_outgoing_voltage
 
             ## save transformer JSON file
             # transformer_hash

--- a/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
@@ -127,7 +127,7 @@ module URBANopt
           # nominal capacity in kVA  (Model.json stores it in VA)
           # TODO: assuming that all windings would have the same rated power, so grabbing first one
           begin
-            t['nominal_capacity'] = item['windings']['value'][0]['rated_power']['value'] / 1000
+            t[:nominal_capacity] = item['windings']['value'][0]['rated_power']['value'] / 1000
           rescue StandardError
           end
 
@@ -144,7 +144,7 @@ module URBANopt
             reactance = item['reactances']['value'][0]['value']
             resistance = item['windings']['value'][0]['resistance']['value']
 
-            t['reactance_resistance_ratio'] = reactance / resistance
+            t[:reactance_resistance_ratio] = reactance / resistance
           rescue StandardError
           end
 
@@ -172,8 +172,8 @@ module URBANopt
             nominal_capacity = nil
             r_r_ratio = nil
             begin
-              nominal_capacity = t_res[t_key]['nominal_capacity']
-              r_r_ratio = t_res[t_key]['reactance_resistance_ratio']
+              nominal_capacity = t_res[t_key][:nominal_capacity]
+              r_r_ratio = t_res[t_key][:reactance_resistance_ratio]
             rescue StandardError
             end
 

--- a/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
@@ -162,8 +162,8 @@ module URBANopt
           if k.include? 'Transformer'
             t_key = k.sub('Transformer.', '')
             # create transformer directory
-            transformer_dir = File.join(@scenario_report.directory_name, k)
-            FileUtils.mkdir_p(File.join(transformer_dir, 'feature_reports'))
+            transformer_dir = Pathname(@scenario_report.directory_name) / k
+            FileUtils.mkdir_p(Pathname(transformer_dir) / 'feature_reports')
 
             # write data to csv
             # store under voltages and over voltages
@@ -194,7 +194,7 @@ module URBANopt
             end
 
             # save transformer CSV report
-            File.write(File.join(transformer_dir, 'feature_reports', 'default_feature_report_opendss.csv'), transformer_csv)
+            File.write(Pathname(transformer_dir) / 'feature_reports' / 'default_feature_report_opendss.csv', transformer_csv)
 
             # create transformer report
             transformer_report = URBANopt::Reporting::DefaultReports::FeatureReport.new(id: k, name: k, directory_name: transformer_dir, feature_type: 'Transformer',
@@ -214,7 +214,7 @@ module URBANopt
             transformer_hash = transformer_report.to_hash
             # transformer_hash.delete_if { |k, v| v.nil? }
 
-            json_name_path = File.join(transformer_dir, 'feature_reports', 'default_feature_report_opendss.json')
+            json_name_path = Pathname(transformer_dir) / 'feature_reports' / 'default_feature_report_opendss.json'
 
             # save the json file
             File.open(json_name_path, 'w') do |f|

--- a/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
+++ b/lib/urbanopt/scenario/scenario_post_processor_opendss.rb
@@ -206,8 +206,8 @@ module URBANopt
             transformer_report.power_distribution.under_voltage_hours = under_voltage_hrs
             transformer_report.power_distribution.nominal_capacity = nominal_capacity
             transformer_report.power_distribution.reactance_resistance_ratio = r_r_ratio
-            transformer_report.power_distribution.reactance_resistance_ratio = t_res[t_key][:incoming_voltage]
-            transformer_report.power_distribution.reactance_resistance_ratio = t_res[t_key][:outgoing_voltage]
+            transformer_report.power_distribution.tx_incoming_voltage = t_res[t_key][:incoming_voltage]
+            transformer_report.power_distribution.tx_outgoing_voltage = t_res[t_key][:outgoing_voltage]
 
             ## save transformer JSON file
             # transformer_hash

--- a/urbanopt-scenario-gem.gemspec
+++ b/urbanopt-scenario-gem.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
   spec.add_runtime_dependency 'sqlite3', '~> 1.6'
   spec.add_runtime_dependency 'urbanopt-core', '~> 0.10.0'
-  spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.8.0'
+  # spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.8.0'
 end


### PR DESCRIPTION
### Pull Request Description
- Read the transformer voltage from Model.json
    - Generated by OpenDSS/Ditto-Reader
- Put the transformer voltages into scenario_report_opendss.json with other transformer data
- Use hash symbols instead of strings for other transformer data as well
- Use Pathname for paths, instead of File.join working with strings
- Fix indenting in Disco post-processor file.

### Checklist (Delete lines that don't apply)

- [x] All ci tests pass (green)
- [x] This branch is up-to-date with develop