### PR TITLE
Upgrade to OpenStudio 3.8 & Ruby 3.2

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -18,8 +18,6 @@ env:
 
 jobs:
   weeknight-tests:
-    # ubuntu-latest works since https://github.com/rbenv/ruby-build/releases/tag/v20220710 (July 10, 2022)
-    # https://github.com/rbenv/ruby-build/discussions/1940
     runs-on: ubuntu-latest
     container:
       image: docker://nrel/openstudio:3.8.0

--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -22,7 +22,7 @@ jobs:
     # https://github.com/rbenv/ruby-build/discussions/1940
     runs-on: ubuntu-latest
     container:
-      image: docker://nrel/openstudio:3.7.0
+      image: docker://nrel/openstudio:3.8.0
     steps:
       - uses: actions/checkout@v4
       - name: Update gems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,7 +194,7 @@ Date Range: 01/15/20 - 03/30/20:
 - Fixed [#83]( https://github.com/urbanopt/urbanopt-scenario-gem/pull/83 ), add multiple pV
 - Fixed [#88]( https://github.com/urbanopt/urbanopt-scenario-gem/pull/88 ), add units to CSV reports
 - Fixed [#89]( https://github.com/urbanopt/urbanopt-scenario-gem/pull/89 ), created Save feature report method
-- Fixed [#91]( https://github.com/urbanopt/urbanopt-scenario-gem/pull/91 ), add total_costruction_cost to reports
+- Fixed [#91]( https://github.com/urbanopt/urbanopt-scenario-gem/pull/91 ), add total_construction_cost to reports
 - Fixed [#95]( https://github.com/urbanopt/urbanopt-scenario-gem/issues/95 ), list datapoint failures
 - Fixed [#98]( https://github.com/urbanopt/urbanopt-scenario-gem/pull/98 ), add power, net power, net energy and apparent power to timeseries results
 - Fixed [#101]( https://github.com/urbanopt/urbanopt-scenario-gem/pull/101 ), fix for unit conversion when timeseries doe not exist

--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-core-gem')
 #  gem 'urbanopt-core', path: '../urbanopt-core-gem'
 # elsif allow_local
-# gem 'urbanopt-core', github: 'URBANopt/urbanopt-core-gem', branch: 'os37'
+gem 'urbanopt-core', github: 'URBANopt/urbanopt-core-gem', branch: 'os38'
 # end
 
 # if allow_local && File.exist?('../openstudio-common-measures-gem')
@@ -41,7 +41,7 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # if allow_local && File.exist?('../urbanopt-reporting-gem')
 # gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
 # elsif allow_local
-# gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
+gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'os38'
 # end
 
 # if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 #   gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'develop'
 # end
 
+gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'dont_raise_when_mistmatch'
+
 # if allow_local && File.exist?('../urbanopt-core-gem')
 #  gem 'urbanopt-core', path: '../urbanopt-core-gem'
 # elsif allow_local

--- a/lib/urbanopt/scenario/logger.rb
+++ b/lib/urbanopt/scenario/logger.rb
@@ -9,7 +9,7 @@ module URBANopt
   module Scenario
     @@logger = Logger.new($stdout)
 
-    # Definining class variable "@@logger" to log errors, info and warning messages.
+    # Defining class variable "@@logger" to log errors, info and warning messages.
     def self.logger
       @@logger
     end

--- a/lib/urbanopt/scenario/scenario_csv.rb
+++ b/lib/urbanopt/scenario/scenario_csv.rb
@@ -48,16 +48,24 @@ module URBANopt
       # Require all simulation mappers in mapper_files_dir
       def load_mapper_files
         # loads default values from extension gem
-        options = OpenStudio::Extension::RunnerConfig.default_config
+        @options = OpenStudio::Extension::RunnerConfig.default_config(@root_dir)
         # check if runner.conf file exists
         if File.exist?(File.join(@root_dir, OpenStudio::Extension::RunnerConfig::FILENAME))
           runner_config = OpenStudio::Extension::RunnerConfig.new(@root_dir)
-          # use the default values overridden with runner.conf values
-          options = options.merge(runner_config.options)
+          # use the default values overridden with runner.conf values where not
+          # nil nor empty strings
+          @options = @options.merge(runner_config.options.reject{|k, v| v.nil? || (v.kind_of?(String) && v === '')})
         end
 
+        if @options.key?(:bundle_install_path)
+          puts "Bundle install path is set to: #{@options[:bundle_install_path]}"
+          @options[:bundle_install_path] = Pathname(@options[:bundle_install_path]).cleanpath
+          puts "Bundle adjusted path is set to: #{@options[:bundle_install_path]}"
+        end
         # bundle path is assigned from the runner.conf if it exists or is assigned in the root_dir
-        bundle_path = !options.key?(:bundle_install_path) || options[:bundle_install_path] === '' ? File.join(@root_dir, '.bundle/install/') : options[:bundle_install_path]
+        # if bundle install path is not provided or is empty, it will be placed in root_dir/.bundle/install, otherwise use the provided path
+        bundle_path = !@options.key?(:bundle_install_path) || @options[:bundle_install_path] === '' ? (Pathname(@root_dir) / '.bundle' / 'install').realpath : @options[:bundle_install_path]
+        puts "Bundle final path is set to: #{bundle_path}"
 
         # checks if bundle path doesn't exist or is empty
         if !Dir.exist?(bundle_path) || Dir.empty?(bundle_path)

--- a/lib/urbanopt/scenario/scenario_csv.rb
+++ b/lib/urbanopt/scenario/scenario_csv.rb
@@ -52,7 +52,7 @@ module URBANopt
         # check if runner.conf file exists
         if File.exist?(File.join(@root_dir, OpenStudio::Extension::RunnerConfig::FILENAME))
           runner_config = OpenStudio::Extension::RunnerConfig.new(@root_dir)
-          # use the default values overriden with runner.conf values
+          # use the default values overridden with runner.conf values
           options = options.merge(runner_config.options)
         end
 

--- a/lib/urbanopt/scenario/scenario_datapoint_base.rb
+++ b/lib/urbanopt/scenario/scenario_datapoint_base.rb
@@ -89,7 +89,7 @@ module URBANopt
       # rubocop: enable Style/EvalWithLocation #:nodoc:
 
       ##
-      # Return true if the datapoint is out of date, false otherwise.  Non-existant files are out of date.
+      # Return true if the datapoint is out of date, false otherwise.  Non-existent files are out of date.
       ##
       # [return:] _Boolean_ - True if the datapoint is out of date, false otherwise.
       def out_of_date?

--- a/lib/urbanopt/scenario/scenario_runner_osw.rb
+++ b/lib/urbanopt/scenario/scenario_runner_osw.rb
@@ -46,11 +46,11 @@ module URBANopt
 
       ##
       # Create and run all SimulationFileOSW for Scenario.
-      # A staged runner is implented to run buildings, then transformers then district systems.
+      # A staged runner is implemented to run buildings, then transformers then district systems.
       # - instantiate openstudio runner to run .osw files.
       # - create simulation files for this scenario.
       # - get feature_type value from in.osw files
-      # - cretae 3 groups to store .osw files (+building_osws+ , +transformer_osws+ , +district_system_osws+)
+      # - create 3 groups to store .osw files (+building_osws+ , +transformer_osws+ , +district_system_osws+)
       # - add each osw file to its corresponding group id +simulation_dir+ is out_of_date
       # - Run osw file groups in order and store simulation failure in a array.
       ##
@@ -78,7 +78,7 @@ module URBANopt
         #   end
         # end
 
-        # cretae 3 groups to store .osw files (+building_osws+ , +transformer_osws+ , +district_system_osws+)
+        # create 3 groups to store .osw files (+building_osws+ , +transformer_osws+ , +district_system_osws+)
         building_osws = []
         transformer_osws = []
         district_system_osws = []

--- a/lib/urbanopt/scenario/simulation_dir_base.rb
+++ b/lib/urbanopt/scenario/simulation_dir_base.rb
@@ -30,7 +30,7 @@ module URBANopt
 
       ##
       # Return true if the simulation is out of date (input files newer than results), false otherwise.
-      # Non-existant simulation input files are out of date.
+      # Non-existent simulation input files are out of date.
       ##
       def out_of_date?
         raise 'out_of_date? is not implemented for SimulationFileBase, override in your class'

--- a/lib/urbanopt/scenario/simulation_dir_osw.rb
+++ b/lib/urbanopt/scenario/simulation_dir_osw.rb
@@ -110,7 +110,7 @@ module URBANopt
 
       ##
       # Return true if the simulation is out of date (input files newer than results), false otherwise.
-      # Non-existant simulation input files are out of date.
+      # Non-existent simulation input files are out of date.
       ##
       def out_of_date?
         if !File.exist?(run_dir)

--- a/lib/urbanopt/scenario/version.rb
+++ b/lib/urbanopt/scenario/version.rb
@@ -5,6 +5,6 @@
 
 module URBANopt
   module Scenario
-    VERSION = '0.12.0'.freeze
+    VERSION = '0.13.0'.freeze
   end
 end

--- a/spec/files/Gemfile
+++ b/spec/files/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '~> 3.2'
+ruby '3.2.2'
 
 # Local gems are useful when developing and integrating the various dependencies.
 # To favor the use of local gems, set the following environment variable:

--- a/spec/files/Gemfile
+++ b/spec/files/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '~> 2.7.0'
+ruby '~> 3.2'
 
 # Local gems are useful when developing and integrating the various dependencies.
 # To favor the use of local gems, set the following environment variable:
@@ -27,16 +27,16 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 #
 
 # pin this dependency to avoid unicode_normalize error
-gem 'addressable', '2.8.1'
+# gem 'addressable', '2.8.1'
 # pin this dependency to avoid using racc dependency (which has native extensions)
-gem 'parser', '3.2.2.2'
+# gem 'parser', '3.2.2.2'
 
 if allow_local && File.exist?('../openstudio-common-measures-gem')
   gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 elsif allow_local
   gem 'openstudio-common-measures', github: 'NREL/openstudio-common-measures-gem', branch: 'develop'
 else
-  gem 'openstudio-common-measures', '~> 0.8.0'
+  gem 'openstudio-common-measures', '~> 0.10.0'
 end
 
 if allow_local && File.exist?('../openstudio-model-articulation-gem')
@@ -44,7 +44,7 @@ if allow_local && File.exist?('../openstudio-model-articulation-gem')
 elsif allow_local
   gem 'openstudio-model-articulation', github: 'NREL/openstudio-model-articulation-gem', branch: 'develop'
 else
-  gem 'openstudio-model-articulation', '~> 0.8.0'
+  gem 'openstudio-model-articulation', '~> 0.10.0'
 end
 
 if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')
@@ -52,7 +52,7 @@ if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')
 elsif allow_local
   gem 'openstudio-load-flexibility-measures', github: 'NREL/openstudio-load-flexibility-measures-gem', branch: 'master'
 else
-  gem 'openstudio-load-flexibility-measures', '~> 0.7.0'
+  gem 'openstudio-load-flexibility-measures', '~> 0.9.0'
 end
 
 if allow_local && File.exist?('../openstudio-ee-gem')
@@ -60,7 +60,7 @@ if allow_local && File.exist?('../openstudio-ee-gem')
 elsif allow_local
   gem 'openstudio-ee', github: 'NREL/openstudio-ee-gem', branch: 'develop'
 else
-  gem 'openstudio-ee', '~> 0.8.0'
+  gem 'openstudio-ee', '~> 0.10.0'
 end
 
 if allow_local && File.exist?('../openstudio-calibration-gem')
@@ -68,24 +68,24 @@ if allow_local && File.exist?('../openstudio-calibration-gem')
 elsif allow_local
   gem 'openstudio-calibration', github: 'NREL/openstudio-calibration-gem', branch: 'develop'
 else
-  gem 'openstudio-calibration', '~> 0.8.0'
+  gem 'openstudio-calibration', '~> 0.10.0'
 end
 
-if allow_local && File.exist?('../urbanopt-geojson-gem')
-  gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
-elsif allow_local
-  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'develop'
-else
-  gem 'urbanopt-geojson', '~> 0.10.0'
-end
+# if allow_local && File.exist?('../urbanopt-geojson-gem')
+#   gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
+# elsif allow_local
+  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'os38'
+# else
+#   gem 'urbanopt-geojson', '~> 0.10.0'
+# end
 
 # NEVER put SCENARIO-GEM in this file...it will make all simulations fail due to the sqlite dependency
 # gem 'urbanopt-scenario', github: 'URBANopt/urbanopt-scenario-gem', branch: 'develop'
 
-if allow_local && File.exist?('../urbanopt-reporting-gem')
-  gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
-elsif allow_local
-  gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'develop'
-else
-  gem 'urbanopt-reporting', '~> 0.8.0'
-end
+# if allow_local && File.exist?('../urbanopt-reporting-gem')
+#   gem 'urbanopt-reporting', path: '../urbanopt-reporting-gem'
+# elsif allow_local
+  gem 'urbanopt-reporting', github: 'URBANopt/urbanopt-reporting-gem', branch: 'os38'
+# else
+#   gem 'urbanopt-reporting', '~> 0.8.0'
+# end

--- a/spec/urbanopt/urbanopt_scenario_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_spec.rb
@@ -7,8 +7,11 @@ require_relative '../spec_helper'
 require_relative '../files/example_feature_file'
 require 'json'
 require 'json-schema'
+require 'logger'
+
 RSpec.describe URBANopt::Scenario do
-  @@logger
+
+  let(:logger) { Logger.new($stdout) }
 
   it 'has a version number' do
     expect(URBANopt::Scenario::VERSION).not_to be nil
@@ -26,7 +29,7 @@ RSpec.describe URBANopt::Scenario do
     name = 'example_scenario'
 
     # copy all files into test directory
-    root_dir = File.join(File.dirname(__FILE__), '../test')
+    root_dir = File.absolute_path(File.join(File.dirname(__FILE__), '../test'))
     Dir.mkdir(root_dir) unless File.exist?(root_dir)
     run_dir = File.join(File.dirname(__FILE__), '../test/example_scenario/')
     FileUtils.cp(File.join(File.dirname(__FILE__), '../files/example_feature_file.json'), File.join(File.dirname(__FILE__), '../test/example_feature_file.json'))
@@ -43,7 +46,7 @@ RSpec.describe URBANopt::Scenario do
     # write a runner.conf in project dir
     options = { gemfile_path: File.join(File.dirname(__FILE__), '../test/Gemfile'), bundle_install_path: File.join(File.dirname(__FILE__), '../test/.bundle/install') }
     File.open(File.join(root_dir, 'runner.conf'), 'w') do |f|
-      f.write(options.to_json)
+      f.write(JSON.pretty_generate(options))
     end
 
     feature_file = ExampleFeatureFile.new(feature_file_path)
@@ -188,7 +191,7 @@ RSpec.describe URBANopt::Scenario do
     # Read scenario json file and validated against schema
     scenario_json = JSON.parse(File.read(scenario_json_file))
 
-    @@logger.info("Schema Validation Errors: #{JSON::Validator.fully_validate(schema, scenario_json)}")
+    logger.info("Schema Validation Errors: #{JSON::Validator.fully_validate(schema, scenario_json)}")
     expect(JSON::Validator.fully_validate(schema, scenario_json).empty?).to be true
 
     # close json file

--- a/spec/urbanopt/urbanopt_scenario_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe URBANopt::Scenario do
 
   let(:logger) { Logger.new($stdout) }
 
+  root_dir = (Pathname(__FILE__).dirname.parent / 'test').cleanpath
+
   it 'has a version number' do
     expect(URBANopt::Scenario::VERSION).not_to be nil
   end
@@ -20,8 +22,8 @@ RSpec.describe URBANopt::Scenario do
   it 'has a logger' do
     expect(URBANopt::Scenario.logger).not_to be nil
     current_level = URBANopt::Scenario.logger.level
-    URBANopt::Scenario.logger.level = Logger::DEBUG
-    expect(URBANopt::Scenario.logger.level).to eq Logger::DEBUG
+    URBANopt::Scenario.logger.level = Logger::ERROR
+    expect(URBANopt::Scenario.logger.level).to eq Logger::ERROR
     URBANopt::Scenario.logger.level = current_level
   end
 
@@ -29,22 +31,21 @@ RSpec.describe URBANopt::Scenario do
     name = 'example_scenario'
 
     # copy all files into test directory
-    root_dir = File.absolute_path(File.join(File.dirname(__FILE__), '../test'))
     Dir.mkdir(root_dir) unless File.exist?(root_dir)
-    run_dir = File.join(File.dirname(__FILE__), '../test/example_scenario/')
-    FileUtils.cp(File.join(File.dirname(__FILE__), '../files/example_feature_file.json'), File.join(File.dirname(__FILE__), '../test/example_feature_file.json'))
-    feature_file_path = File.join(File.dirname(__FILE__), '../test/example_feature_file.json')
-    FileUtils.cp_r(File.join(File.dirname(__FILE__), '../files/mappers'), File.join(File.dirname(__FILE__), '../test/mappers'), remove_destination: true)
-    FileUtils.cp_r(File.join(File.dirname(__FILE__), '../files/weather'), File.join(File.dirname(__FILE__), '../test/weather'), remove_destination: true)
-    mapper_files_dir = File.join(File.dirname(__FILE__), '../test/mappers/')
-    FileUtils.cp(File.join(File.dirname(__FILE__), '../files/example_scenario.csv'), File.join(File.dirname(__FILE__), '../test/example_scenario.csv'))
-    csv_file = File.join(File.dirname(__FILE__), '../test/example_scenario.csv')
+    run_dir = root_dir / 'example_scenario/'
+    FileUtils.cp(root_dir.parent / 'files' / 'example_feature_file.json', root_dir / 'example_feature_file.json')
+    feature_file_path = root_dir / 'example_feature_file.json'
+    FileUtils.cp_r(root_dir.parent / 'files' / 'mappers', root_dir.parent / 'test' / 'mappers', remove_destination: true)
+    FileUtils.cp_r(root_dir.parent / 'files' / 'weather', root_dir.parent / 'test' / 'weather', remove_destination: true)
+    mapper_files_dir = root_dir / 'mappers/'
+    FileUtils.cp(root_dir.parent / 'files' / 'example_scenario.csv', root_dir / 'example_scenario.csv')
+    csv_file = root_dir / 'example_scenario.csv'
     num_header_rows = 1
 
-    FileUtils.cp(File.join(File.dirname(__FILE__), '../files/Gemfile'), File.join(File.dirname(__FILE__), '../test/Gemfile'))
+    FileUtils.cp(root_dir.parent / 'files' / 'Gemfile', root_dir / 'Gemfile')
 
     # write a runner.conf in project dir
-    options = { gemfile_path: File.join(File.dirname(__FILE__), '../test/Gemfile'), bundle_install_path: File.join(File.dirname(__FILE__), '../test/.bundle/install') }
+    options = { gemfile_path: root_dir / 'Gemfile', bundle_install_path: root_dir / '.bundle' / 'install' }
     File.open(File.join(root_dir, 'runner.conf'), 'w') do |f|
       f.write(JSON.pretty_generate(options))
     end
@@ -95,7 +96,7 @@ RSpec.describe URBANopt::Scenario do
     expect(File.exist?(simulation_dirs[2].run_dir)).to be true
 
     # pass Gemfile and bundle paths to extension gem runner, otherwise it will use this gem's and that doesn't work b/c of native gems
-    options = { gemfile_path: File.join(File.dirname(__FILE__), '../test/Gemfile'), bundle_install_path: File.join(File.dirname(__FILE__), '../test/.bundle/install'), skip_config: false }
+    options = { gemfile_path: root_dir / 'Gemfile', bundle_install_path: root_dir / '.bundle' / 'install', skip_config: false }
     simulation_dirs = scenario_runner.run(scenario, false, options)
     if clear_results
       expect(simulation_dirs.size).to eq(3)
@@ -217,8 +218,8 @@ RSpec.describe URBANopt::Scenario do
 
   it 'can integrate opendss results' do
     # generate opendss results for testing
-    opendss_results_source = File.join(File.dirname(__FILE__), '../files/opendss_outputs/')
-    opendss_results_destination = File.join(File.dirname(__FILE__), '../test/example_scenario')
+    opendss_results_source = root_dir.parent / 'files' / 'opendss_outputs/'
+    opendss_results_destination = root_dir / 'example_scenario'
     FileUtils.copy_entry opendss_results_source, opendss_results_destination
     # post_process opendss results
     opendss_post_processor = URBANopt::Scenario::OpenDSSPostProcessor.new($scenario_result, 'opendss')
@@ -227,8 +228,8 @@ RSpec.describe URBANopt::Scenario do
 
   it 'can integrate disco results' do
     # generate disco results for testing
-    disco_results_source = File.join(File.dirname(__FILE__), '../files/disco_outputs/')
-    disco_results_destination = File.join(File.dirname(__FILE__), '../test/example_scenario')
+    disco_results_source = root_dir.parent / 'files' / 'disco_outputs/'
+    disco_results_destination = root_dir / 'example_scenario'
     FileUtils.copy_entry disco_results_source, disco_results_destination
     # post_process disco results
     disco_post_processor = URBANopt::Scenario::DISCOPostProcessor.new($scenario_result, 'disco')

--- a/spec/urbanopt/urbanopt_scenario_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_spec.rb
@@ -8,7 +8,7 @@ require_relative '../files/example_feature_file'
 require 'json'
 require 'json-schema'
 RSpec.describe URBANopt::Scenario do
-  @@logger ||= URBANopt::Reporting::DefaultReports.logger
+  @@logger
 
   it 'has a version number' do
     expect(URBANopt::Scenario::VERSION).not_to be nil

--- a/spec/urbanopt/urbanopt_scenario_spec.rb
+++ b/spec/urbanopt/urbanopt_scenario_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe URBANopt::Scenario do
     # Get scenario schema hash
     schema = validator.schema
 
-    # Read scenario json file and validated againt schema
+    # Read scenario json file and validated against schema
     scenario_json = JSON.parse(File.read(scenario_json_file))
 
     @@logger.info("Schema Validation Errors: #{JSON::Validator.fully_validate(schema, scenario_json)}")
@@ -205,7 +205,7 @@ RSpec.describe URBANopt::Scenario do
     scenario_csv_schema_headers = validator.csv_headers
     expect((scenario_csv_headers_with_no_units & scenario_csv_schema_headers)).to eq(scenario_csv_headers_with_no_units)
 
-    # Read feature_reprot json file and validate against schema
+    # Read feature_report json file and validate against schema
     Dir["#{File.dirname(__FILE__)}/../**/*default_feature_reports.json"].each do |json_file|
       feature_json = JSON.parse(File.read(json_file))
       expect(JSON::Validator.fully_validate(schema[:definitions][:FeatureReport][:properties], feature_json).empty?).to be true

--- a/urbanopt-scenario-gem.gemspec
+++ b/urbanopt-scenario-gem.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.7.0'
+  spec.required_ruby_version = '~> 3.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.1'
-  spec.add_development_dependency 'rspec', '~> 3.12'
-  spec.add_development_dependency 'simplecov', '~> 0.18.2'
-  spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
+  spec.add_development_dependency 'bundler', '~> 2.4.10'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'simplecov', '0.22.0'
+  spec.add_development_dependency 'simplecov-lcov', '0.8.0'
   spec.add_runtime_dependency 'sqlite3', '~> 1.6.0'
-  spec.add_runtime_dependency 'urbanopt-core', '~> 0.11.0'
-  spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.10.0'
+  # spec.add_runtime_dependency 'urbanopt-core', '~> 0.11.0'
+  # spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.10.0'
 end

--- a/urbanopt-scenario-gem.gemspec
+++ b/urbanopt-scenario-gem.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 3.2'
+  # We support exactly Ruby v3.2.2 because os-extension requires bundler==2.4.10 and that requires Ruby 3.2.2: https://stdgems.org/bundler/
+  # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
+  spec.required_ruby_version = '3.2.2'
 
-  spec.add_development_dependency 'bundler', '~> 2.4.10'
-  spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'

--- a/urbanopt-scenario-gem.gemspec
+++ b/urbanopt-scenario-gem.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'simplecov', '0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '0.8.0'
-  spec.add_runtime_dependency 'sqlite3', '~> 1.6.0'
+  spec.add_runtime_dependency 'sqlite3', '~> 2.0.0'
   # spec.add_runtime_dependency 'urbanopt-core', '~> 0.11.0'
   # spec.add_runtime_dependency 'urbanopt-reporting', '~> 0.10.0'
 end


### PR DESCRIPTION
### Resolves #[issue number here]

### Pull Request Description

The current version of OpenStudio, [v3.8](https://github.com/NREL/OpenStudio/releases) includes a major breaking change to move from Ruby 2.7.2 to Ruby 3.2.2.

### Checklist (Delete lines that don't apply)

- [ ] Unit tests have been added or updated
- [ ] Documentation has been modified as needed
- [ ] All ci tests pass (green)
- [ ] An [issue](https://github.com/urbanopt/urbanopt-scenario-gem/issues) has been created (which will be used for the changelog)
- [x] This branch is up-to-date with develop
